### PR TITLE
Delete bot instance while waiting

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
 from movie_quote_twitter_bot.factory import Factory
 from movie_quote_twitter_bot.config import Config
+import time
 import os
 
 if __name__ == "__main__":
 
     config = Config(os.environ)
-    bot = Factory(config).build()
-
     while True:
+        bot = Factory(config).build()
         bot.run()
-        bot.wait()
+        del bot
+        time.sleep(config.get("idle_period"))

--- a/movie_quote_twitter_bot/bot.py
+++ b/movie_quote_twitter_bot/bot.py
@@ -1,6 +1,3 @@
-import time
-
-
 class Bot:
 
     def __init__(
@@ -9,18 +6,13 @@ class Bot:
         text_clip,
         video_clip,
         twitter,
-        gif,
-        idle_period
+        gif
     ):
         self.subs = subs
         self.text_clip = text_clip
         self.video_clip = video_clip
         self.twitter = twitter
         self.gif = gif
-        self.idle_period = idle_period
-
-    def wait(self):
-        time.sleep(self.idle_period)
 
     def run(self):
         quote = self.subs.get_random()

--- a/movie_quote_twitter_bot/factory.py
+++ b/movie_quote_twitter_bot/factory.py
@@ -34,6 +34,5 @@ class Factory():
             text_clip,
             video_clip,
             twitter,
-            gif,
-            self.config.get("idle_period")
+            gif
         )

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -10,14 +10,12 @@ class TestBot(TestCase):
         self.video_clip = mock.Mock()
         self.twitter = mock.Mock()
         self.gif = mock.Mock()
-        self.idle_period = 10
         self.bot = Bot(
             self.subs,
             self.text_clip,
             self.video_clip,
             self.twitter,
-            self.gif,
-            self.idle_period
+            self.gif
         )
 
     def test_runnig(self):
@@ -39,8 +37,3 @@ class TestBot(TestCase):
             text_clip_mock
         )
         self.twitter.post_gif.assert_called_once_with(quote_mock.content)
-
-    @mock.patch('movie_quote_twitter_bot.bot.time.sleep')
-    def test_waiting(self, m_sleep):
-        self.bot.wait()
-        m_sleep.assert_called_once_with(self.idle_period)


### PR DESCRIPTION
This is a bit of a shot in the dark, but I expect memory to go low while waiting if I remove the bot instance using `del`